### PR TITLE
Trying to close a non existing connection

### DIFF
--- a/kuyruk/__init__.py
+++ b/kuyruk/__init__.py
@@ -14,7 +14,7 @@ from kuyruk.worker import Worker
 from kuyruk.events import EventMixin
 from kuyruk.connection import Connection
 
-__version__ = '0.24.0'
+__version__ = '0.24.1'
 __all__ = ['Kuyruk', 'Task', 'Worker']
 
 


### PR DESCRIPTION
When kuyruk tries to recover an errored connection, it doesn't take into account that it may not be created. 
Though I am not sure how this situation arose and how can opening a connection throw these exceptions:

```
pika.exceptions.ConnectionClosed
pika.exceptions.ChannelClosed
```

Here is the stacktrace that led to discovery:

```
kuyruk in _open_channel
AttributeError: 'NoneType' object has no attribute 'close'

Stacktrace (most recent call last):

  File "flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "newrelic/hooks/framework_flask.py", line 74, in wrapper_Flask_handle_exception
    return wrapped(*args, **kwargs)
  File "flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "newrelic/hooks/framework_flask.py", line 28, in handler_wrapper
    return wrapped(*args, **kwargs)
  File "putio/api2/apiblueprint.py", line 28, in wrapper
    rv = f(*args, **kwargs)
  File "putio/api2/files.py", line 391, in delete
    uf.user_delete()
  File "putio/filesystem/models/userfile.py", line 482, in user_delete
    solr2.delete(user_file_id)
  File "putio/helpers/__init__.py", line 367, in f_retry
    return f(*args, **kwargs)
  File "putio/kuyruk2.py", line 38, in __call__
    return super(PutioTask, self).__call__(*args, **kwargs)
  File "kuyruk/task.py", line 96, in inner
    rv = f(self, *args, **kwargs)
  File "kuyruk/task.py", line 55, in inner
    return f(self, *args, **kwargs)
  File "kuyruk/task.py", line 150, in __call__
    expiration=expiration)
  File "kuyruk/task.py", line 195, in send_to_queue
    with self.queue(host=host, local=local) as queue:
  File "python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "kuyruk/task.py", line 216, in queue
    yield Queue(queue_, self.kuyruk.channel(), local_)
  File "kuyruk/__init__.py", line 125, in channel
    self._channel = self._open_channel()
  File "kuyruk/__init__.py", line 160, in _open_channel
    self._connection.close()
```
