### PR TITLE
Removed unnecessary argparse dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'amqp>=1.4.6',
         'setproctitle>=1.1.8',
         'blinker>=1.3',
-        'argparse>=1.2.1',
     ],
     description='Simple task queue',
     long_description=read('README.rst'),


### PR DESCRIPTION
`argparse` module was added to Python 2.7 as a replacement for `optparse`, and it is built into Python 2.7 and 3.2+.