### PR TITLE
Make use of `pkg_resources` optional

### DIFF
--- a/kuyruk/__main__.py
+++ b/kuyruk/__main__.py
@@ -7,7 +7,11 @@ from __future__ import absolute_import
 import sys
 import logging
 import argparse
-import pkg_resources
+
+try:
+    import pkg_resources
+except ImportError:
+    pkg_resources = None
 
 from kuyruk import __version__, importer, Kuyruk
 from kuyruk.worker import Worker
@@ -38,13 +42,14 @@ def main():
         '-l', '--local', action="store_true",
         help='append hostname to the queue name')
 
-    # Add additional subcommands from extensions.
-    for entry_point in pkg_resources.iter_entry_points("kuyruk.commands"):
-        command_func, help_text, customize_parser = entry_point.load()
-        ext_parser = subparsers.add_parser(entry_point.name, help=help_text)
-        ext_parser.set_defaults(func=command_func)
-        if customize_parser:
-            customize_parser(ext_parser)
+    if pkg_resources is not None:
+        # Add additional subcommands from extensions.
+        for entry_point in pkg_resources.iter_entry_points("kuyruk.commands"):
+            command_func, help_text, customize_parser = entry_point.load()
+            ext_parser = subparsers.add_parser(entry_point.name, help=help_text)
+            ext_parser.set_defaults(func=command_func)
+            if customize_parser:
+                customize_parser(ext_parser)
 
     # Parse arguments
     args = parser.parse_args()

--- a/kuyruk/config.py
+++ b/kuyruk/config.py
@@ -3,7 +3,11 @@ import sys
 import ast
 import types
 import logging
-import pkg_resources
+
+try:
+    import pkg_resources
+except ImportError:
+    pkg_resources = None
 
 from kuyruk import importer
 
@@ -117,7 +121,8 @@ class Config(object):
         setattr(self, key, value)
 
 
-# Add additional config keys from extensions.
-for entry_point in pkg_resources.iter_entry_points("kuyruk.config"):
-    for k, v in entry_point.load().items():
-        setattr(Config, k, v)
+if pkg_resources is not None:
+    # Add additional config keys from extensions.
+    for entry_point in pkg_resources.iter_entry_points("kuyruk.config"):
+        for k, v in entry_point.load().items():
+            setattr(Config, k, v)


### PR DESCRIPTION
`pkg_resources` is a part of `setuptools` package, which is neither available nor used in Anaconda Python for entrypoints.

When `setuptools` is not installed, Kuyruk fails with the following traceback:

```
import: 'kuyruk'
Traceback (most recent call last):
  File "/staged-recipes/build_artefacts/test-tmp_dir/run_test.py", line 26, in <module>
    import kuyruk
  File "/opt/conda/envs/_test/lib/python2.7/site-packages/kuyruk/__init__.py", line 9, in <module>
    from kuyruk.config import Config
  File "/opt/conda/envs/_test/lib/python2.7/site-packages/kuyruk/config.py", line 6, in <module>
    import pkg_resources
ImportError: No module named pkg_resources
```

So, you cannot even `import kuyruk`.