### PR TITLE
Fixed encoding name so Windows Python 3.4+ can install Kuyruk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 import os
 import re
 from setuptools import setup


### PR DESCRIPTION
Without this fix, Kuyruk cannot be installed on Windows with Python 3; it is throwing the following exception:

```
  File "setup.py", line 1
SyntaxError: encoding problem: utf8
```

Log: https://ci.appveyor.com/project/conda-forge/staged-recipes/build/1.0.8257/job/h4vl9b2sipdk1hi8

I have tested this small fix and it works. It would be nice if you can push a new release once this is merged, so the Anaconda package can be built for all platforms.