### PR TITLE
Enhanced `Config.from_object` so it can handle a string object as an object name to import

### DIFF
--- a/kuyruk/config.py
+++ b/kuyruk/config.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import sys
 import ast
@@ -59,6 +60,13 @@ class Config(object):
 
     def from_object(self, obj):
         """Load values from an object."""
+        if isinstance(obj, str):
+            module_name, obj_name = obj.rsplit('.', 1)
+            obj_module = importlib.import_module(module_name)
+            try:
+                obj = getattr(obj_module, obj_name)
+            except AttributeError as e:
+                raise ImportError(e)
         for key in dir(obj):
             if key.isupper():
                 value = getattr(obj, key)


### PR DESCRIPTION
Having this PR, you can pass a string to `Config.from_object` and it will be imported and loaded:

```python
import kuyruk

k = kuyruk.Kuyruk()
k.config.from_object('config.DevelopmentConfig')
```

This is how it is implemented in Flask, and since I have noticed quite a similarity to Flask design, I decided to make them closer in terms of my use-case.