### PR TITLE
Remove TCP_USER_TIMEOUT parameter for MacOS

### DIFF
--- a/kuyruk/kuyruk.py
+++ b/kuyruk/kuyruk.py
@@ -65,6 +65,11 @@ class Kuyruk:
     def connection(self) -> Iterator[amqp.Connection]:
         """Returns a new connection as a context manager."""
         TCP_USER_TIMEOUT = 18  # constant is available on Python 3.6+.
+        socket_settings = {TCP_USER_TIMEOUT: self.config.RABBIT_CONNECT_TIMEOUT}
+
+        if sys.platform.startswith('darwin'):
+            del socket_settings[TCP_USER_TIMEOUT]
+
         conn = amqp.Connection(
             host="%s:%s" % (self.config.RABBIT_HOST, self.config.RABBIT_PORT),
             userid=self.config.RABBIT_USER,
@@ -73,7 +78,7 @@ class Kuyruk:
             connect_timeout=self.config.RABBIT_CONNECT_TIMEOUT,
             read_timeout=self.config.RABBIT_READ_TIMEOUT,
             write_timeout=self.config.RABBIT_WRITE_TIMEOUT,
-            socket_settings={TCP_USER_TIMEOUT: self.config.RABBIT_CONNECT_TIMEOUT},
+            socket_settings=socket_settings,
         )
         conn.connect()
         logger.info('Connected to RabbitMQ')


### PR DESCRIPTION
OSX does not support the TCP_USER_TIMEOUT option and kuyruk is failing to start.

Please, point me what else should be done for this PR to be accepted. Thanks!