### PR TITLE
Set global QoS to False

### DIFF
--- a/kuyruk/worker.py
+++ b/kuyruk/worker.py
@@ -132,7 +132,7 @@ class Worker:
         with self.kuyruk.channel() as ch:
             # Set prefetch count to 1. If we don't set this, RabbitMQ keeps
             # sending messages while we are already working on a message.
-            ch.basic_qos(0, 1, True)
+            ch.basic_qos(0, 1, False)
 
             self._declare_queues(ch)
             self._consume_queues(ch)


### PR DESCRIPTION
RabbitMQ quorum queues do not support Global QoS -> https://www.rabbitmq.com/quorum-queues.html#global-qos